### PR TITLE
Expand definition of comments to include `## `.

### DIFF
--- a/ftplugin/spicy.vim
+++ b/ftplugin/spicy.vim
@@ -1,1 +1,1 @@
-set commentstring=#%s
+set comments=b:#,b:##


### PR DESCRIPTION
This allows to reformat Spicy documentation strings.
