### PR TITLE
Add character highlighting

### DIFF
--- a/syntax/spicy.vim
+++ b/syntax/spicy.vim
@@ -13,6 +13,7 @@ syntax include @spicySh syntax/sh.vim
 let b:current_syntax = 'spicy'
 
 syntax region spicyString start=/"/ skip=/\\"/ end =/"/ contains=spicyEscapeChar
+syntax match spicyCharacter /'.'/
 syn match spicyEscapeChar /\\./ contained
 
 syntax keyword spicyBoolean True False
@@ -58,6 +59,7 @@ highlight default link spicyBTestKeyword SpecialComment
 highlight default link spicyBTestOther SpecialComment
 
 highlight default link spicyString String
+highlight default link spicyCharacter Character
 highlight default link spicyEscapeChar SpecialChar
 highlight default link spicyNumber Number
 highlight default link spicyType Type


### PR DESCRIPTION
Nice to have characters highlighting, but main reason I want this is because this would start a string:

```
local c = '"';
```

Then the string wouldn't end getting highlighted, and braces would get mismatched even if I put a `#"` after to even quotes :/